### PR TITLE
initializing Fastlane structures

### DIFF
--- a/fastlane/metadata/android/de/full_description.txt
+++ b/fastlane/metadata/android/de/full_description.txt
@@ -1,6 +1,6 @@
 <p><i>NiceFeed</i> ist ein RSS Reader für Android. Ich wollte eine App, die mich bezüglich aktueller News auf dem Laufenden hält – und mir gleichzeitig dabei hilft, Programmieren in Kotlin zu lernen.</p>
 <p>RSS ist eine bereits seit langem existierende Technologie, und es gibt bereits viele Apps dafür; doch viele davon erscheinen mir zu klobig, schwer zu navigieren, und vollgestopft mit Features die ich nicht benötige. Mein Ziel ist eine attraktive und intuitive App, leichtgewichtig und doch komplett funtionell, ohne viel Schnickschnack.</p>
-<p>Ich freue mich über Feedback und schätze dies sehr – insebsondere wenn jemand Bugs findet, oder Ideen für neue Features hat. Ebenso bin ich offen für „Contributions“.</p>
+<p>Ich freue mich über Feedback und schätze dies sehr – insbesondere wenn jemand Bugs findet, oder Ideen für neue Features hat. Ebenso bin ich offen für „Contributions“.</p>
 <p><br>Features:</p><ul>
 <li>RSS-Parsing Dank <a href='https://github.com/prof18/RSS-Parser'>RSS Parser</a></li>
 <li>Die Suche wird angetrieben von der <a href='https://developer.feedly.com/v3/search/'>Feedly Search API</a></li>

--- a/fastlane/metadata/android/de/full_description.txt
+++ b/fastlane/metadata/android/de/full_description.txt
@@ -1,0 +1,9 @@
+<p><i>NiceFeed</i> ist ein RSS Reader für Android. Ich wollte eine App, die mich bezüglich aktueller News auf dem Laufenden hält – und mir gleichzeitig dabei hilft, Programmieren in Kotlin zu lernen.</p>
+<p>RSS ist eine bereits seit langem existierende Technologie, und es gibt bereits viele Apps dafür; doch viele davon erscheinen mir zu klobig, schwer zu navigieren, und vollgestopft mit Features die ich nicht benötige. Mein Ziel ist eine attraktive und intuitive App, leichtgewichtig und doch komplett funtionell, ohne viel Schnickschnack.</p>
+<p>Ich freue mich über Feedback und schätze dies sehr – insebsondere wenn jemand Bugs findet, oder Ideen für neue Features hat. Ebenso bin ich offen für „Contributions“.</p>
+<p><br>Features:</p><ul>
+<li>RSS-Parsing Dank <a href='https://github.com/prof18/RSS-Parser'>RSS Parser</a></li>
+<li>Die Suche wird angetrieben von der <a href='https://developer.feedly.com/v3/search/'>Feedly Search API</a></li>
+<li>OPML Support (Import und Export) via <a href='https://github.com/rometools/rome'>Rome Tools</a></li>
+<li>Die Möglichkeit, Feeds in Kategorien zu organisieren</li>
+<li>Star/unstar sowie Markieren von Einträgen als (un)gelesen</li></ul>

--- a/fastlane/metadata/android/de/short_description.txt
+++ b/fastlane/metadata/android/de/short_description.txt
@@ -1,0 +1,1 @@
+Leichtgewichtiger RSS-Feed Reader und News-Aggregator

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,8 @@
+<p><i>NiceFeed</i> is an RSS Reader for Android. I wanted something to help me keep up with the news while learning Kotlin at the same time. RSS is an old technology and there are already many readers out there, but I find many of them clunky, hard to navigate, and jam-packed with features I don't need. The aim is an attractive and intuitive app, leightweight but fully functional with not too many frills.</p>
+<p>I would truly appreciate any and all feedback, especially if you find any issues or bugs, or have ideas for new features. I am also open to contributions.</p>
+<p><br>Features:</p><ul>
+<li>RSS parsing provided by <a href='https://github.com/prof18/RSS-Parser'>RSS Parser</a></li>
+<li>Search engine powered by <a href='https://developer.feedly.com/v3/search/'>Feedly Search API</a></li>
+<li>OPML support (importing and exporting) provided by <a href='https://github.com/rometools/rome'>Rome Tools</a></li>
+<li>Ability to organize feeds by category</li>
+<li>Star/unstar and mark entries as read/unread</li></ul>

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Lightweight RSS feed reader and news aggregator


### PR DESCRIPTION
This can not only be used for publishing to Google Play – but will also be helpful should you decide to publish your app on [F-Droid](https://f-droid.org/). So one place to maintain your descriptions, screenshots etc – and have them available where needed.

As you plan to update your screenshots anyhow: consider placing them into `fastlane/metadata/android/<locale>/images/phoneScreenshots` so they are available where looked for (by Fastlane Supply as well as by F-Droid). Find more details [here](https://gitlab.com/snippets/1895688), including what else could/should go inside these structures and where.